### PR TITLE
Feat : eslint에 타입 체크 및 네이밍 컨벤션 체크 기능을 추가하였습니다.

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -11,13 +11,45 @@ export default defineConfig([
     files: ['**/*.{ts,tsx}'],
     extends: [
       js.configs.recommended,
-      tseslint.configs.recommended,
+      tseslint.configs.recommendedTypeChecked,
       reactHooks.configs.flat.recommended,
       reactRefresh.configs.vite,
     ],
     languageOptions: {
       ecmaVersion: 2020,
       globals: globals.browser,
+      parserOptions: {
+        project: ['./tsconfig.app.json', './tsconfig.node.json'],
+        tsconfigRootDir: import.meta.dirname,
+      },
     },
+    rules: {
+      "@typescript-eslint/naming-convention": [
+        "error",
+        // 변수 / 함수 → camelCase
+        {
+          selector: "variableLike",
+          format: ["camelCase"]
+        },
+        // 타입 / 인터페이스 / enum / class → PascalCase
+        {
+          selector: "typeLike",
+          format: ["PascalCase"]
+        },
+        // const → camelCase 또는 UPPER_CASE
+        {
+          selector: "variable",
+          modifiers: ["const"],
+          format: ["camelCase", "UPPER_CASE"]
+        },
+        // boolean 변수 → camelCase + is / has / can / should로 시작
+        {
+          selector: "variable",
+          types: ["boolean"],
+          format: ["camelCase"],
+          prefix: ["is", "has", "can", "should"]
+        }
+      ]
+    }
   },
 ])


### PR DESCRIPTION
### 설정 변경
- tseslint.configs.recommended
- -> tseslint.configs.recommendedTypeChecked

### 변수 네이밍 컨벤션
- 타입 / 인터페이스 / enum / class → PascalCase
- const → camelCase 또는 UPPER_CASE
- 변수 / 함수 → camelCase
- boolean 변수 → camelCase + is / has / can / should로 시작

### ESLint 적용
VSCode에서 ESLint 확장 설치