### PR TITLE
Feature/reservation session token연동

### DIFF
--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -26,7 +26,10 @@ type SlugReservationEntry = {
 
 type SlugReservationCache = Record<string, SlugReservationEntry>;
 
+// slug 예약 캐시를 저장하는 localStorage 키
 const STORAGE_KEY = "create-capsule-slug-reservations";
+// 한 세션에서 중복 확인할 수 있는 slug 최대 개수
+const MAX_SLUG_RESERVATIONS_PER_SESSION = 3;
 
 // 만료된 예약을 캐시에서 제거한다
 function pruneExpiredReservations(cache: SlugReservationCache): SlugReservationCache {
@@ -258,7 +261,7 @@ export default function CreateCapsulePage() {
       (entry) => entry.reservationSessionToken === reservationSessionToken,
     ).length;
 
-    if (sessionReservationCount >= 3) {
+    if (sessionReservationCount >= MAX_SLUG_RESERVATIONS_PER_SESSION) {
       setSlugMessage("주소는 최대 3개까지만 확인할 수 있습니다.");
       setSlugMessageStatus("error");
       return;

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -182,7 +182,6 @@ export default function CreateCapsulePage() {
   // slug 예약 관련 상태를 모두 초기화한다.
   const resetSlugReservation = () => {
     setReservationToken("");
-    setReservationSessionToken("");
     setReservedSlug("");
     setSlugMessage("");
     setSlugMessageStatus(undefined);

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import {
@@ -104,6 +104,8 @@ export default function CreateCapsulePage() {
 
   const [isCheckingSlug, setIsCheckingSlug] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+  const isCheckingSlugRef = useRef(false);
+  const isCreatingRef = useRef(false);
 
   // 캐시가 바뀔 때마다 localStorage에 반영한다.
   useEffect(() => {
@@ -180,6 +182,7 @@ export default function CreateCapsulePage() {
   // slug 예약 관련 상태를 모두 초기화한다.
   const resetSlugReservation = () => {
     setReservationToken("");
+    setReservationSessionToken("");
     setReservedSlug("");
     setSlugMessage("");
     setSlugMessageStatus(undefined);
@@ -211,20 +214,8 @@ export default function CreateCapsulePage() {
   const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nextSlug = e.target.value.replace(/\s+/g, "");
     const nextCache = pruneExpiredReservations(reservationCache);
-    const nextReservation = nextSlug ? nextCache[nextSlug] : undefined;
-
     setReservationCache(nextCache);
     setSlug(nextSlug);
-
-    // 같은 slug를 다시 입력하면 새 요청 없이 기존 예약 정보를 즉시 복원한다.
-    if (nextReservation) {
-      setReservationToken(nextReservation.reservationToken);
-      setReservationSessionToken(nextReservation.reservationSessionToken ?? "");
-      setReservedSlug(nextReservation.reservedSlug);
-      setSlugMessage("사용 가능한 주소입니다.");
-      setSlugMessageStatus("success");
-      return;
-    }
 
     // 캐시에 없는 slug로 바뀌면 예약 상태를 초기화한다.
     resetSlugReservation();
@@ -235,11 +226,11 @@ export default function CreateCapsulePage() {
   };
 
   const handleCheckSlug = async () => {
-    if (isCheckingSlug) return;
+    if (isCheckingSlugRef.current) return;
 
     const trimmedSlug = slug.trim();
     const nextCache = pruneExpiredReservations(reservationCache);
-    const cachedReservation = trimmedSlug ? nextCache[trimmedSlug] : undefined;
+    const nextReservationSessionToken = reservationSessionToken;
 
     setReservationCache(nextCache);
 
@@ -247,20 +238,9 @@ export default function CreateCapsulePage() {
       return;
     }
 
-    // 이미 확인한 slug라면 서버를 다시 호출하지 않고 캐시를 재사용한다.
-    if (cachedReservation) {
-      setSlug(cachedReservation.reservedSlug);
-      setReservationToken(cachedReservation.reservationToken);
-      setReservationSessionToken(cachedReservation.reservationSessionToken ?? "");
-      setReservedSlug(cachedReservation.reservedSlug);
-      setSlugMessage("사용 가능한 주소입니다.");
-      setSlugMessageStatus("success");
-      return;
-    }
-
     // 같은 세션에서 이미 3개 예약했으면 더 이상 확인하지 못하게 막는다.
     const sessionReservationCount = Object.values(nextCache).filter(
-      (entry) => entry.reservationSessionToken === reservationSessionToken,
+      (entry) => entry.reservationSessionToken === nextReservationSessionToken,
     ).length;
 
     if (sessionReservationCount >= MAX_SLUG_RESERVATIONS_PER_SESSION) {
@@ -269,6 +249,7 @@ export default function CreateCapsulePage() {
       return;
     }
 
+    isCheckingSlugRef.current = true;
     setIsCheckingSlug(true);
     startLoading();
 
@@ -277,7 +258,7 @@ export default function CreateCapsulePage() {
       const response = await slugReservationMutation.mutateAsync({
         data: {
           slug: trimmedSlug,
-          reservationSessionToken: reservationSessionToken || undefined,
+          reservationSessionToken: nextReservationSessionToken || undefined,
         },
       });
 
@@ -297,16 +278,27 @@ export default function CreateCapsulePage() {
         },
       }));
     } catch (error) {
+      if (getErrorCode(error) === "SLUG_ALREADY_IN_USE") {
+        setReservationCache((prev) => {
+          const next = { ...prev };
+          delete next[trimmedSlug];
+          return next;
+        });
+      }
+
       resetSlugReservation();
       setSlugMessage(getErrorMessage(error));
       setSlugMessageStatus("error");
     } finally {
+      isCheckingSlugRef.current = false;
       setIsCheckingSlug(false);
       stopLoading();
     }
   };
 
   const handleCreateCapsule = async () => {
+    if (isCreatingRef.current) return;
+
     const trimmedTitle = title.trim();
     const trimmedSlug = slug.trim();
 
@@ -330,6 +322,7 @@ export default function CreateCapsulePage() {
       return;
     }
 
+    isCreatingRef.current = true;
     setIsCreating(true);
     startLoading();
 
@@ -374,6 +367,7 @@ export default function CreateCapsulePage() {
 
       openNoticeModal(getErrorMessage(error));
     } finally {
+      isCreatingRef.current = false;
       setIsCreating(false);
       stopLoading();
     }

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -253,6 +253,17 @@ export default function CreateCapsulePage() {
       return;
     }
 
+    // 같은 세션에서 이미 3개 예약했으면 더 이상 확인하지 못하게 막는다.
+    const sessionReservationCount = Object.values(nextCache).filter(
+      (entry) => entry.reservationSessionToken === reservationSessionToken,
+    ).length;
+
+    if (sessionReservationCount >= 3) {
+      setSlugMessage("주소는 최대 3개까지만 확인할 수 있습니다.");
+      setSlugMessageStatus("error");
+      return;
+    }
+
     setIsCheckingSlug(true);
     startLoading();
 

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -1,4 +1,5 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import axios from "axios";
 import { useNavigate } from "react-router-dom";
 import {
   usePostCapsules,
@@ -10,9 +11,65 @@ import { useLoadingStore } from "../shared/store/useLoadingStore";
 import { useModalStore } from "../shared/store/useModalStore";
 import { getErrorMessage } from "../shared/utils/error";
 import { buildCapsuleDetailPath } from "../shared/utils/routes";
+import type { ErrorResponse } from "../shared/schemas";
 import { createCapsuleBodySchema } from "../shared/schemas";
 
 type FieldMessageStatus = "success" | "error" | undefined;
+
+// slug 하나의 예약 정보 (localStorage에 저장됨)
+type SlugReservationEntry = {
+  reservationToken: string;
+  reservationSessionToken?: string;
+  reservedSlug: string;
+  reservedUntil: string; // 예약 만료 시각
+};
+
+type SlugReservationCache = Record<string, SlugReservationEntry>;
+
+const STORAGE_KEY = "create-capsule-slug-reservations";
+
+// 만료된 예약을 캐시에서 제거한다
+function pruneExpiredReservations(cache: SlugReservationCache): SlugReservationCache {
+  const now = Date.now();
+
+  return Object.fromEntries(
+    Object.entries(cache).filter(([, entry]) => {
+      const reservedUntil = Date.parse(entry.reservedUntil);
+
+      return Number.isFinite(reservedUntil) && reservedUntil > now;
+    }),
+  );
+}
+
+// 브라우저를 다시 열어도 최근 slug 예약을 복원할 수 있도록 localStorage를 읽는다.
+function readReservationCache(): SlugReservationCache {
+  try {
+    const stored = window.localStorage.getItem(STORAGE_KEY);
+
+    if (!stored) return {};
+
+    return pruneExpiredReservations(JSON.parse(stored) as SlugReservationCache);
+  } catch {
+    return {};
+  }
+}
+
+// 예약 캐시가 바뀔 때마다 localStorage에 동기화한다.
+function writeReservationCache(cache: SlugReservationCache) {
+  if (Object.keys(cache).length === 0) {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } else {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(cache));
+  }
+}
+
+function getErrorCode(error: unknown) {
+  if (axios.isAxiosError<ErrorResponse>(error)) {
+    return error.response?.data?.error?.code;
+  }
+
+  return undefined;
+}
 
 export default function CreateCapsulePage() {
   const navigate = useNavigate();
@@ -31,13 +88,24 @@ export default function CreateCapsulePage() {
   const [password, setPassword] = useState("");
 
   const [reservationToken, setReservationToken] = useState("");
+  const [reservationSessionToken, setReservationSessionToken] = useState("");
   const [reservedSlug, setReservedSlug] = useState("");
   const [slugMessage, setSlugMessage] = useState("");
   const [slugMessageStatus, setSlugMessageStatus] =
     useState<FieldMessageStatus>(undefined);
 
+  // 이전에 확인한 slug 예약들을 저장해두는 캐시
+  const [reservationCache, setReservationCache] = useState<SlugReservationCache>(() =>
+    readReservationCache(),
+  );
+
   const [isCheckingSlug, setIsCheckingSlug] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+
+  // 캐시가 바뀔 때마다 localStorage에 반영한다.
+  useEffect(() => {
+    writeReservationCache(reservationCache);
+  }, [reservationCache]);
 
   const verifyCreateCapsule = createCapsuleBodySchema.safeParse({
     slug,
@@ -45,7 +113,12 @@ export default function CreateCapsulePage() {
     openAt: openDate?.toISOString(),
     password,
     reservationToken,
+    reservationSessionToken,
   });
+
+  const currentReservation = reservedSlug
+    ? pruneExpiredReservations(reservationCache)[reservedSlug]
+    : undefined;
 
   const fieldErrors = !verifyCreateCapsule.success
     ? verifyCreateCapsule.error.flatten().fieldErrors
@@ -55,11 +128,7 @@ export default function CreateCapsulePage() {
     slug: slugError = [],
     title: titleError = [],
     password: passwordError = [],
-    // openAt: openAtError = [],
-    // reservationToken: tokenError = [],
-  } = !verifyCreateCapsule.success
-    ? verifyCreateCapsule.error.flatten().fieldErrors
-    : {};
+  } = fieldErrors;
 
   const titleFieldStatus: FieldMessageStatus =
     title.length === 0
@@ -83,11 +152,16 @@ export default function CreateCapsulePage() {
 
   const titleFieldMessage = titleError.length === 0 ? "" : titleError[0];
   const slugFieldMessage =
-    slugMessage ||
-    (slug.length > 0 && slugError.length === 0 ? "" : slugError[0]);
+    slugMessage || (slug.length > 0 && slugError.length === 0 ? "" : slugError[0]);
   const passwordFieldMessage = password.length === 0 ? "" : passwordError[0];
 
-  const isButtonDisabled = isCreating || !verifyCreateCapsule.success;
+  const isReservationValid =
+    !!currentReservation &&
+    currentReservation.reservationToken === reservationToken &&
+    currentReservation.reservedSlug === reservedSlug &&
+    reservedSlug === slug;
+  const isButtonDisabled =
+    isCreating || isCheckingSlug || !verifyCreateCapsule.success || !isReservationValid;
 
   // alert 대신 공용 modal store를 통해 안내 메시지를 띄운다.
   const openNoticeModal = (message: string, onConfirm?: () => void) => {
@@ -100,6 +174,7 @@ export default function CreateCapsulePage() {
     });
   };
 
+  // slug 예약 관련 상태를 모두 초기화한다.
   const resetSlugReservation = () => {
     setReservationToken("");
     setReservedSlug("");
@@ -107,17 +182,49 @@ export default function CreateCapsulePage() {
     setSlugMessageStatus(undefined);
   };
 
+  // 같은 세션에서 예약했던 slug들을 캐시에서 제거한다.
+  const clearSessionCache = (createdSlug: string) => {
+    setReservationCache((prev) => {
+      // 세션 토큰이 없으면 생성한 slug만 제거
+      if (!reservationSessionToken) {
+        const next = { ...prev };
+        delete next[createdSlug];
+        return next;
+      }
+
+      // 세션 토큰이 있으면 같은 세션의 모든 slug 제거
+      return Object.fromEntries(
+        Object.entries(prev).filter(
+          ([, entry]) => entry.reservationSessionToken !== reservationSessionToken,
+        ),
+      );
+    });
+  };
+
   const handleTitleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     setTitle(e.target.value);
   };
 
   const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const nextSlug = e.target.value;
+    const nextSlug = e.target.value.replace(/\s+/g, "");
+    const nextCache = pruneExpiredReservations(reservationCache);
+    const nextReservation = nextSlug ? nextCache[nextSlug] : undefined;
+
+    setReservationCache(nextCache);
     setSlug(nextSlug);
 
-    if (reservedSlug && reservedSlug !== nextSlug.trim()) {
-      resetSlugReservation();
+    // 같은 slug를 다시 입력하면 새 요청 없이 기존 예약 정보를 즉시 복원한다.
+    if (nextReservation) {
+      setReservationToken(nextReservation.reservationToken);
+      setReservationSessionToken(nextReservation.reservationSessionToken ?? "");
+      setReservedSlug(nextReservation.reservedSlug);
+      setSlugMessage("사용 가능한 주소입니다.");
+      setSlugMessageStatus("success");
+      return;
     }
+
+    // 캐시에 없는 slug로 바뀌면 예약 상태를 초기화한다.
+    resetSlugReservation();
   };
 
   const handlePasswordChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -126,23 +233,53 @@ export default function CreateCapsulePage() {
 
   const handleCheckSlug = async () => {
     const trimmedSlug = slug.trim();
+    const nextCache = pruneExpiredReservations(reservationCache);
+    const cachedReservation = trimmedSlug ? nextCache[trimmedSlug] : undefined;
+
+    setReservationCache(nextCache);
+
+    if (!trimmedSlug || slugError.length > 0) {
+      return;
+    }
+
+    // 이미 확인한 slug라면 서버를 다시 호출하지 않고 캐시를 재사용한다.
+    if (cachedReservation) {
+      setSlug(cachedReservation.reservedSlug);
+      setReservationToken(cachedReservation.reservationToken);
+      setReservationSessionToken(cachedReservation.reservationSessionToken ?? "");
+      setReservedSlug(cachedReservation.reservedSlug);
+      setSlugMessage("사용 가능한 주소입니다.");
+      setSlugMessageStatus("success");
+      return;
+    }
 
     setIsCheckingSlug(true);
     startLoading();
 
     try {
-      // 중복 확인과 동시에 slug 예약 토큰을 발급받아 생성 요청에 사용한다.
+      // 같은 생성 흐름을 이어가기 위해 reservationSessionToken을 함께 보낸다.
       const response = await slugReservationMutation.mutateAsync({
         data: {
           slug: trimmedSlug,
+          reservationSessionToken: reservationSessionToken || undefined,
         },
       });
 
       setReservationToken(response.reservationToken);
+      setReservationSessionToken(response.reservationSessionToken);
       setReservedSlug(response.slug);
       setSlug(response.slug);
       setSlugMessage("사용 가능한 주소입니다.");
       setSlugMessageStatus("success");
+      setReservationCache((prev) => ({
+        ...pruneExpiredReservations(prev),
+        [response.slug]: {
+          reservationToken: response.reservationToken,
+          reservationSessionToken: response.reservationSessionToken,
+          reservedSlug: response.slug,
+          reservedUntil: response.reservedUntil,
+        },
+      }));
     } catch (error) {
       resetSlugReservation();
       setSlugMessage(getErrorMessage(error));
@@ -156,6 +293,7 @@ export default function CreateCapsulePage() {
   const handleCreateCapsule = async () => {
     const trimmedTitle = title.trim();
     const trimmedSlug = slug.trim();
+
     if (!verifyCreateCapsule.success) {
       openModal({
         title: "안내!",
@@ -167,6 +305,12 @@ export default function CreateCapsulePage() {
         ),
         option: "oneButton",
       });
+      return;
+    }
+
+    if (!isReservationValid) {
+      setSlugMessage("슬러그 예약이 만료되었어요. 다시 중복 확인해 주세요.");
+      setSlugMessageStatus("error");
       return;
     }
 
@@ -182,14 +326,30 @@ export default function CreateCapsulePage() {
           password,
           openAt: openDate?.toISOString() ?? "",
           reservationToken,
+          reservationSessionToken: reservationSessionToken || undefined,
         },
       });
+
+      // 방 생성 성공 → 같은 세션에서 선점했던 다른 slug들도 함께 제거한다.
+      clearSessionCache(trimmedSlug);
+      setReservationSessionToken("");
+      resetSlugReservation();
 
       // 생성 성공 후 확인 버튼을 누르면 상세 페이지로 이동한다.
       openNoticeModal("타임캡슐이 생성되었습니다.", () => {
         void navigate(buildCapsuleDetailPath(response.slug));
       });
     } catch (error) {
+      if (getErrorCode(error) === "SLUG_RESERVATION_MISMATCH") {
+        // 서버에서 예약이 깨졌다고 응답하면 캐시도 함께 비운다.
+        clearSessionCache(trimmedSlug);
+        setReservationSessionToken("");
+        resetSlugReservation();
+        setSlugMessage("슬러그 예약이 만료되었어요. 다시 중복 확인해 주세요.");
+        setSlugMessageStatus("error");
+        return;
+      }
+
       openNoticeModal(getErrorMessage(error));
     } finally {
       setIsCreating(false);
@@ -244,11 +404,12 @@ export default function CreateCapsulePage() {
             rightSlot={
               <Button
                 variant="sm"
+                className="text-center flex-none"
                 onClick={() => void handleCheckSlug()}
                 enterFlow={true}
-                disabled={isCheckingSlug || !slug.trim()}
+                disabled={isCheckingSlug || !slug.trim() || slugError.length > 0 || isReservationValid}
               >
-                {isCheckingSlug ? "확인 중" : "중복 확인"}
+                {isCheckingSlug ? "확인 중..." : isReservationValid ? "사용 가능" : "중복 확인"}
               </Button>
             }
             onChange={handleSlugChange}

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -235,6 +235,8 @@ export default function CreateCapsulePage() {
   };
 
   const handleCheckSlug = async () => {
+    if (isCheckingSlug) return;
+
     const trimmedSlug = slug.trim();
     const nextCache = pruneExpiredReservations(reservationCache);
     const cachedReservation = trimmedSlug ? nextCache[trimmedSlug] : undefined;
@@ -354,12 +356,18 @@ export default function CreateCapsulePage() {
         void navigate(buildCapsuleDetailPath(response.slug));
       });
     } catch (error) {
-      if (getErrorCode(error) === "SLUG_RESERVATION_MISMATCH") {
-        // 서버에서 예약이 깨졌다고 응답하면 캐시도 함께 비운다.
+      const errorCode = getErrorCode(error);
+
+      if (errorCode === "SLUG_RESERVATION_MISMATCH" || errorCode === "SLUG_ALREADY_IN_USE") {
+        // 예약이 깨졌거나 이미 사용 중인 slug면 캐시도 함께 비운다.
         clearSessionCache(trimmedSlug);
         setReservationSessionToken("");
         resetSlugReservation();
-        setSlugMessage("슬러그 예약이 만료되었어요. 다시 중복 확인해 주세요.");
+        setSlugMessage(
+          errorCode === "SLUG_ALREADY_IN_USE"
+            ? "이미 사용 중인 주소입니다. 다른 주소를 입력해 주세요."
+            : "슬러그 예약이 만료되었어요. 다시 중복 확인해 주세요.",
+        );
         setSlugMessageStatus("error");
         return;
       }

--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -214,8 +214,18 @@ export default function CreateCapsulePage() {
   const handleSlugChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const nextSlug = e.target.value.replace(/\s+/g, "");
     const nextCache = pruneExpiredReservations(reservationCache);
+    const nextReservation = nextSlug ? nextCache[nextSlug] : undefined;
     setReservationCache(nextCache);
     setSlug(nextSlug);
+
+    if (nextReservation) {
+      setReservationToken(nextReservation.reservationToken);
+      setReservationSessionToken(nextReservation.reservationSessionToken ?? "");
+      setReservedSlug(nextReservation.reservedSlug);
+      setSlugMessage("사용 가능한 주소입니다.");
+      setSlugMessageStatus("success");
+      return;
+    }
 
     // 캐시에 없는 slug로 바뀌면 예약 상태를 초기화한다.
     resetSlugReservation();

--- a/src/shared/schemas/capsules/create-capsule.ts
+++ b/src/shared/schemas/capsules/create-capsule.ts
@@ -13,6 +13,7 @@ export const createCapsuleBodySchema = z.object({
   password: passwordSchema,
   openAt: isoDateTimeStringSchema,
   reservationToken: z.string(),
+  reservationSessionToken: z.string().optional(),
 });
 
 export const createCapsuleResponseSchema = capsuleBaseResponseSchema;

--- a/src/shared/schemas/capsules/slug-reservation.ts
+++ b/src/shared/schemas/capsules/slug-reservation.ts
@@ -3,11 +3,13 @@ import { isoDateTimeStringSchema, slugSchema } from "./shared";
 
 export const createSlugReservationBodySchema = z.object({
   slug: slugSchema,
+  reservationSessionToken: z.string().optional(),
 });
 
 export const slugReservationResponseSchema = z.object({
   slug: slugSchema,
   reservationToken: z.string(),
+  reservationSessionToken: z.string(),
   reservedUntil: isoDateTimeStringSchema,
 });
 
@@ -17,3 +19,6 @@ export type CreateSlugReservationBody = z.infer<
 export type SlugReservationResponse = z.infer<
   typeof slugReservationResponseSchema
 >;
+
+
+// 

--- a/src/shared/utils/error.ts
+++ b/src/shared/utils/error.ts
@@ -4,7 +4,7 @@ const errorMessages = {
   INVALID_INPUT: "요청 값을 확인해 주세요.",
   FORBIDDEN_PASSWORD: "비밀번호가 일치하지 않습니다.",
   CAPSULE_NOT_FOUND : "존재하지 않는 캡슐입니다.",
-  SLUG_ALREADY_IN_US: "이미 사용 중인 slug 입니다.",
+  SLUG_ALREADY_IN_USE: "이미 사용 중인 slug 입니다.",
   SLUG_RESERVATION_MISMATCH: "slug 예약 토큰 검증에 실패했습니다.",
   DUPLICATE_NICKNAME: "중복된 닉네임입니다.",
   MESSAGE_LIMIT_EXCEEDED: "메시지 작성 가능 개수를 초과했습니다.",
@@ -15,6 +15,9 @@ const errorMessages = {
 } as const;
 
 type ErrorCode = keyof typeof errorMessages;
+
+export const getErrorMessageByCode = (errorCode: ErrorCode): string =>
+  errorMessages[errorCode];
 
 export const getErrorMessage = (error: unknown): string => {
   let errorMessage = "알 수 없는 오류가 발생했습니다.";
@@ -30,3 +33,4 @@ export const getErrorMessage = (error: unknown): string => {
   }
   return errorMessage;
 };
+


### PR DESCRIPTION
## 작업 내용
- slug reservation / create capsule 스키마에 `reservationSessionToken` 반영
- 타임캡슐 생성 페이지에 slug 예약 세션 처리 로직 추가
- slug 예약 캐시 복원 및 만료/불일치 처리 반영
- 예약 세션당 확인 가능 개수 제한 (3개) 추가
- 에러 메시지 오타 수정
- 더블클릭으로 인한 중복 요청 방지
- 생성 실패 시 SLUG_ALREADY_IN_USE 에러도 캐시 정리하도록 처리

## 상세 변경
- `slug-reservation.ts`
  - slug 예약 요청/응답 스키마에 `reservationSessionToken` 반영
- `create-capsule.ts`
  - 캡슐 생성 요청 스키마에 `reservationSessionToken` 반영
- `CreateCapsulePage.tsx`
  - slug 중복 확인 시 `reservationSessionToken` 전달
  - 생성 요청 시 `reservationToken`, `reservationSessionToken` 함께 전달
  - localStorage 기반 slug 예약 캐시 복원/정리 로직 추가
  - 예약 만료 및 `SLUG_RESERVATION_MISMATCH` 처리 반영
  - 중복 확인 버튼 UX 및 예약 유효성 검사 정리
  - 예약 세션당 확인 가능한 slug 최대 3개로 제한

## 기능
- 방 주소를 중복 확인하면, 잠시 동안 그 주소를 내가 먼저 사용할 수 있도록 선점 가능
- 한 번 확인한 주소는 브라우저를 새로고침해도 일정 시간 동안 다시 불러올 수 있음
- 같은 흐름에서 여러 주소를 확인한 뒤 하나를 선택해 타임캡슐 생성 가능
- 방을 만들고 나면, 같은 흐름에서 미리 확인해뒀던 다른 주소들은 자동으로 정리
- 주소 예약이 만료되었거나 더 이상 유효하지 않으면, 다시 중복 확인하도록 안내
- 이미 확인이 끝난 주소는 버튼에 `사용 가능`으로 표시.
- 잘못된 주소 형식이면 중복 확인 버튼이 동작하지 않음.
- 같은 흐름에서 주소를 확인할 수 있는 개수는 최대 3개로 제한
- 빠른 연속 클릭으로 인한 중복 요청 방지