### PR TITLE
chore: API 동기화 워크플로우에서 빌드 단계 제거

### DIFF
--- a/.github/workflows/sync-orval-from-backend.yml
+++ b/.github/workflows/sync-orval-from-backend.yml
@@ -44,9 +44,6 @@ jobs:
       - name: Generate Orval client
         run: pnpm orval
 
-      - name: Build project
-        run: pnpm build
-
       - name: Fetch backend OpenAPI snapshots
         id: backend-openapi
         shell: bash


### PR DESCRIPTION
## #️⃣ 연관된 작업

- 백엔드 OpenAPI 변경이 FE Orval 동기화 PR로 전달되는 흐름 개선

## 📝 작업 내용

- 자동화 봇(.github/workflows/sync-orval-from-backend.yml)의 본질적인 목적은 "백엔드 API가 바뀌었으니, 새 스펙으로 업데이트된 클라이언트 코드를 PR로 띄워 줄게. 확인해봐!" 라고 알려주는 것입니다.

- 하지만 현재는 이 봇이 자신이 만든 파일이 빌드에 통과할 때까지 깐깐하게 스스로 검사하고 터져버리는 탓에 PR조차 안 올려주고 있는 상황입니다. 따라서 봇은 무조건 변경된(에러가 포함된 채로라도) 코드를 PR에 올려놓도록 빌드 단계를 지워주고, 프론트엔드 개발자가 다음과 같은 흐름으로 일하는 것이 정석입니다.

## 🔍 그래서 어떻게 바뀌나?

백엔드에서 감지한 변경(이번에는 `version` 칼럼 추가)에 맞게 orval 코드를 생성하고, 무조건적으로 PR을 올립니다.
기존에는 너무 깐깐하게 빌드를 하다 터졌는데, 이렇게 하면 터지지 않고 프론트가 직접 처리하게 됩니다.

## ✅ 기대 효과

- 원래 순기능이었던 프론트엔드-백엔드 간 스펙 공유를 할 수 있게 됩니다.

## 📌 변경 파일

- `.github/workflows/sync-orval-from-backend.yml`
