### PR TITLE
fix : 카카오 브라우저 공유 실패 시 링크 복사로 폴백 처리

### DIFF
--- a/src/features/capsule/hooks/useShare.ts
+++ b/src/features/capsule/hooks/useShare.ts
@@ -8,14 +8,23 @@ export type ShareUrlParams = {
   url: string;
 };
 
-// 카카오 SDK 전역 타입 선언
+type KakaoShareOptions = {
+  objectType: "text";
+  text: string;
+  link: {
+    mobileWebUrl: string;
+    webUrl: string;
+  };
+  buttonTitle: string;
+};
+
 declare global {
   interface Window {
-    Kakao: {
+    Kakao?: {
       isInitialized: () => boolean;
       init: (key: string) => void;
       Share: {
-        sendDefault: (options: object) => void;
+        sendDefault: (options: KakaoShareOptions) => void;
       };
     };
   }
@@ -29,20 +38,28 @@ function isMobile() {
   return /Android|iPhone|iPad|iPod|Mobile/i.test(navigator.userAgent);
 }
 
+function isKakaoBrowser() {
+  if (typeof navigator === "undefined") {
+    return false;
+  }
+
+  return /KAKAOTALK/i.test(navigator.userAgent);
+}
+
 function isKakaoAvailable() {
   return typeof window !== "undefined" && !!window.Kakao;
 }
 
 function initKakao() {
-  if (!isKakaoAvailable()) return false;
-  if (!window.Kakao.isInitialized()) {
-    window.Kakao.init(import.meta.env.VITE_KAKAO_JS_KEY as string);
+  if (!isKakaoAvailable() || !import.meta.env.VITE_KAKAO_JS_KEY) {
+    return false;
   }
-  return window.Kakao.isInitialized();
-}
 
-function isKakaoBrowser() {
-  return /KAKAOTALK/i.test(navigator.userAgent);
+  if (!window.Kakao?.isInitialized()) {
+    window.Kakao?.init(import.meta.env.VITE_KAKAO_JS_KEY);
+  }
+
+  return !!window.Kakao?.isInitialized();
 }
 
 function fallbackCopyText(text: string) {
@@ -65,9 +82,12 @@ function fallbackCopyText(text: string) {
 
 export function useShare() {
   const canShare =
-    typeof navigator !== "undefined"
-    && typeof navigator.share === "function"
-    && isMobile();
+    isKakaoBrowser()
+    || (
+      typeof navigator !== "undefined"
+      && typeof navigator.share === "function"
+      && isMobile()
+    );
 
   const shareUrl = async ({ title, text, url }: ShareUrlParams) => {
     try {
@@ -77,35 +97,33 @@ export function useShare() {
       }
       // /TODO
 
-      // 카카오 브라우저에서는 Web Share API가 동작하지 않으므로 카카오 링크를 사용한다.
-      if (isKakaoBrowser() && initKakao()) {
-        console.log("[share] using Kakao Share");
+      // 카카오 브라우저에서는 Kakao Share를 먼저 시도하고, 실패하면 링크 복사로 안내한다.
+      if (isKakaoBrowser()) {
+        try {
+          if (initKakao()) {
+            console.log("[share] using Kakao Share");
 
-        window.Kakao.Share.sendDefault({
-          objectType: "feed",
-          content: {
-            title,
-            description: text ?? "",
-            imageUrl: `${window.location.origin}/icons.svg`,
-            link: {
-              mobileWebUrl: url,
-              webUrl: url,
-            },
-          },
-          buttons: [
-            {
-              title: "타임캡슐 보러가기",
+            window.Kakao?.Share.sendDefault({
+              objectType: "text",
+              text: [title, text].filter(Boolean).join("\n"),
               link: {
                 mobileWebUrl: url,
                 webUrl: url,
               },
-            },
-          ],
-        });
-        return;
+              buttonTitle: "타임캡슐 보러가기",
+            });
+            return;
+          }
+        } catch (error) {
+          console.warn("[share] Kakao Share failed, falling back to copy", error);
+        }
       }
 
-      if (canShare) {
+      if (
+        typeof navigator !== "undefined"
+        && typeof navigator.share === "function"
+        && isMobile()
+      ) {
         console.log("[share] using Web Share API");
 
         await navigator.share({
@@ -137,6 +155,10 @@ export function useShare() {
       console.warn("[share] clipboard API is not available");
       alert("링크 복사에 실패했어요. 다시 시도해주세요.");
     } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") {
+        return;
+      }
+
       console.error("[share] failed", error);
       alert("공유에 실패했어요. 다시 시도해주세요.");
     }

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
   readonly VITE_API_URL: string;
+  readonly VITE_KAKAO_JS_KEY: string;
 }
 
 interface ImportMeta {


### PR DESCRIPTION
## 작업 내용
- 카카오 브라우저에서 공유가 실패할 때 링크 복사로 자연스럽게 이어지도록 수정
- 모바일 Web Share 취소(뒤로가기)를 실패로 처리하지 않도록 보완
- 카카오 공유 관련 타입 선언을 정리했습니다.

## 상세 변경
- Kakao Share가 실패하면 곧바로 링크 복사 fallback으로 이어지도록 수정
- 복사에 성공한 경우 `링크를 복사했어요.` 안내가 노출
- 모바일 브라우저에서 Web Share 창을 열었다가 사용자가 취소한 경우 `AbortError`는 무시하도록 처리
- `window.Kakao` 전역 타입과 `VITE_KAKAO_JS_KEY` 타입을 추가해 타입 안정성을 보완
- 카카오 브라우저에서도 공유 버튼 문구가 `공유하기` 의도와 맞게 보이도록 `canShare` 정리