### PR TITLE
fix:로컬스토리지에 slug남는 오류 수정

### DIFF
--- a/src/pages/CreateCapsulePage.tsx
+++ b/src/pages/CreateCapsulePage.tsx
@@ -245,10 +245,8 @@ export default function CreateCapsulePage() {
       return;
     }
 
-    // 같은 세션에서 이미 3개 예약했으면 더 이상 확인하지 못하게 막는다.
-    const sessionReservationCount = Object.values(nextCache).filter(
-      (entry) => entry.reservationSessionToken === nextReservationSessionToken,
-    ).length;
+    // localStorage에 남아 있는 유효한 slug 예약이 3개 이상이면 중복 확인을 막는다.
+    const sessionReservationCount = Object.keys(nextCache).length;
 
     if (sessionReservationCount >= MAX_SLUG_RESERVATIONS_PER_SESSION) {
       setSlugMessage("주소는 최대 3개까지만 확인할 수 있습니다.");


### PR DESCRIPTION
## 작업 내용
- 타임캡슐 주소 중복확인 3개 제한 기준을 보완했습니다.

## 상세 변경
- 중복확인 제한 개수를 현재 세션 기준이 아니라 localStorage에 남아 있는 유효한 slug 예약 개수 기준으로 계산하도록 수정했습니다.
- 새로고침 이후에도 동일한 기준으로 3개 제한이 유지되도록 정리했습니다.
